### PR TITLE
Non-breaking functionality extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,25 @@ It will display `X min. read`.
 
 ### Customization
 
-You can cutomize the output by passing the second argument as a string.
+You can cutomize the output by passing additional arguments.
 
 Ejs:
 ```
-<%- readingTime(page.content, 'min.') %>
+<%- readingTime(page.content, 'min.', wordsperminute) %>
 ```
 Swig:
 ```
-{{ readingTime(page.content, 'min.') }}
+{{ readingTime(page.content, 'min.', wordsperminute) }}
 ```
 Jade:
 ```
-span= readingTime(page.content, 'min.')
+span= readingTime(page.content, 'min.', wordsperminute)
 ```
 
-It will display `X min.`.
+where:  
+ `'min.'` - second argument - any string that represents suffx. Default is 'min. read'  
+ `wpm` - number  - words per minute. Default is 150.  
+ Both arguments are optional.  
 
 ## License
 MIT

--- a/lib/readingtime.js
+++ b/lib/readingtime.js
@@ -14,6 +14,5 @@ module.exports = function(content, suffix, wpm) {
         }));
 
     var readingTime = Math.ceil(words / wpm);
-    readingTime < 1 ? readingTime = 1 : readingTime;
-    return readingTime + ' ' + suffix;
+    return readingTime < 1 ? 1 + ' ' + suffix : readingTime + ' ' + suffix
 };

--- a/lib/readingtime.js
+++ b/lib/readingtime.js
@@ -3,8 +3,24 @@ var wordCount = require('word-count');
 
 module.exports = function(content, suffix, wpm) {
 
-    suffix = suffix || 'min. read';
-    wpm = wpm || 150;
+    // Check if suffix provided is not a string
+    if (suffix && typeof suffix !== "string") {
+        console && console.warn("Second argument [suffix] must be a string.\nUsing default parameters.");
+        suffix = 'min. read';
+    };
+
+    !suffix && (suffix = 'min. read');
+    // defaults for omitted parameter.     
+    // This way we can pass third argument and omit second.
+
+
+    if (wpm && typeof wpm !== "number") {
+        console && console.warn("Third parameter [reading speed] must be a number\nUsing default parameters.");
+        wpm = 150;
+    };
+
+    !wpm && (wpm = 150);
+    // if speed is not provided then default is used.
 
     var words = wordCount(htmlToText.fromString(
         content, {
@@ -13,6 +29,6 @@ module.exports = function(content, suffix, wpm) {
             wordwrap: false
         }));
 
-    var readingTime = Math.ceil(words / wpm);
+    var readingTime = Math.round(words / wpm);
     return readingTime < 1 ? '1 ' + suffix : readingTime + ' ' + suffix
 };

--- a/lib/readingtime.js
+++ b/lib/readingtime.js
@@ -14,6 +14,6 @@ module.exports = function(content, suffix, wpm) {
         }));
 
     var readingTime = Math.ceil(words / wpm);
-    readingTime <= 1 ? readingTime = 1 : readingTime;
+    readingTime < 1 ? readingTime = 1 : readingTime;
     return readingTime + ' ' + suffix;
 };

--- a/lib/readingtime.js
+++ b/lib/readingtime.js
@@ -1,19 +1,19 @@
 var htmlToText = require('html-to-text');
 var wordCount = require('word-count');
 
-module.exports = function(content, prefix) {
-  prefix = !prefix ? 'min. read' : prefix;
-  var text = htmlToText.fromString(content, {
-    ignoreImage: false,
-    ignoreHref: true,
-    wordwrap: false
-  });
+module.exports = function(content, suffix, wpm) {
 
-  var words = wordCount(text);
-  var speed = 150;
+    suffix = suffix || 'min. read';
+    wpm = wpm || 150;
 
-  var rt = Math.round(words / speed);
-  var readingTime = rt <= 1 ? 1 : rt;
+    var words = wordCount(htmlToText.fromString(
+        content, {
+            ignoreImage: false,
+            ignoreHref: true,
+            wordwrap: false
+        }));
 
-  return readingTime + ' ' + prefix;
+    var readingTime = Math.ceil(words / wpm);
+    readingTime <= 1 ? readingTime = 1 : readingTime;
+    return readingTime + ' ' + suffix;
 };

--- a/lib/readingtime.js
+++ b/lib/readingtime.js
@@ -14,5 +14,5 @@ module.exports = function(content, suffix, wpm) {
         }));
 
     var readingTime = Math.ceil(words / wpm);
-    return readingTime < 1 ? 1 + ' ' + suffix : readingTime + ' ' + suffix
+    return readingTime < 1 ? '1 ' + suffix : readingTime + ' ' + suffix
 };


### PR DESCRIPTION
- Added third **optional** words per minute argument. Defaults to 150 words.
- Removed unnecessary code.
- Fixed documentation.
- Simpler arguments verification
- Extensive arguments handling. If arguments are corrupt the defaults are used.  
- Console warnings if arguments are invalid
- Now it is possible to omit the second argument and provide the reading speed `func(page.content, , 200)`
- Also `prefix` variable name made no sense.  
